### PR TITLE
tell Automake that we will not follow GNU Standards

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ if test x"$GIT_REVISION" != x""; then
     AC_DEFINE_UNQUOTED([GIT_REVISION], ["$GIT_REVISION"], [GIT revision])
 fi
 
-AM_INIT_AUTOMAKE(subdir-objects dist-bzip2 no-dist-gzip)
+AM_INIT_AUTOMAKE(subdir-objects dist-bzip2 no-dist-gzip foreign)
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])


### PR DESCRIPTION
NEWS and README are mandatory for autoconf. Fixes problem introduced in
b1a81b385ddabb704b4cea64fda56abb9928c3c3

closes https://github.com/nfc-tools/libnfc/pull/346
fixes https://github.com/nfc-tools/libnfc/issues/347
